### PR TITLE
Fix build by removing String.h include

### DIFF
--- a/src/TLog.h
+++ b/src/TLog.h
@@ -21,7 +21,6 @@
 #define _H_LOG_TEE
 
 #include <Arduino.h>
-#include <String.h>
 #include <Print.h>
 
 #include <stddef.h>


### PR DESCRIPTION
This include is missing and not needed when building to ESP32 using platformio. Needs testing on other platforms.