### PR TITLE
Syslog ip option

### DIFF
--- a/src/SyslogStream.cpp
+++ b/src/SyslogStream.cpp
@@ -41,10 +41,15 @@ size_t SyslogStream::write(uint8_t c) {
       WiFiUDP syslog;
 
       if (syslog.begin(_syslogPort)) {
-        if (_dest)
-          syslog.beginPacket(_dest, _syslogPort);
-        else
+        if (_useIpDestination){
+          syslog.beginPacket(_destIp, _syslogPort);
+        }
+        else if (_destHost){
+          syslog.beginPacket(_destHost, _syslogPort);
+        }
+        else{
           syslog.beginPacket(WiFi.gatewayIP(), _syslogPort);
+        }
         if (_raw)
           syslog.printf("%s\n", logbuff);
         else {

--- a/src/SyslogStream.h
+++ b/src/SyslogStream.h
@@ -27,13 +27,22 @@ class SyslogStream : public TLog {
   public:
     SyslogStream(const uint16_t syslogPort = 514) : _syslogPort(syslogPort) {};
     void setPort(uint16_t port) { _syslogPort = port; }
-    void setDestination(const char * dest) { _dest = dest; }
+    void setDestination(const char * dest) {
+      _destHost = dest;
+      _useIpDestination = false;
+    }
+    void setDestination(IPAddress dest) {
+      _destIp = dest;
+      _useIpDestination = true;
+    }
     void setRaw(bool raw) { _raw = raw; }
     virtual size_t write(uint8_t c);
     virtual void begin() { _logging = true; }
     virtual void end() { _logging = false; }
   private:
-    const char * _dest;
+    const char * _destHost;
+    IPAddress _destIp;
+    bool _useIpDestination = false;
     uint16_t _syslogPort;
     char logbuff[512]; // 1024 seems to be to large for some syslogd's.
     size_t at = 0;

--- a/src/TLog.h
+++ b/src/TLog.h
@@ -21,7 +21,6 @@
 #define _H_LOG_TEE
 
 #include <Arduino.h>
-#include <String.h>
 #include <Print.h>
 
 #include <stddef.h>


### PR DESCRIPTION
Hi! Currently there is only options to use hostname or default to gateway ip. Here is an addition that allow the use of ip-addresses.

WiFiUDP library only takes hostname as `const char*` ( https://www.arduino.cc/reference/en/libraries/wifi/wifiudp.beginpacket/ )